### PR TITLE
feat: Add executable to pubspec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all install
+
+all: install
+
+install:
+	@echo "Fetching Dart dependencies..."
+	@dart pub get
+	@echo "Activating package globally..."
+	@dart pub global activate . --source path --overwrite
+	@echo "Setup complete."

--- a/README.md
+++ b/README.md
@@ -12,9 +12,18 @@ The script is runnable to move the file to match the new location of the lib fil
 
 ## How to Install
 
+### Using `make`
+
+1. Clone the repo
+2. Run `make install` in the root of the project
+   - This will install the script `sync_test` globally
+
+### Manually
+
 1. Clone the repo
 2. Run `dart pub get` in the root of the project
 3. Run `dart pub global activate . --source path --overwrite` in the root of the project
+   - This will install the script `sync_test` globally
 
 ## How to run
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,17 @@ think of the following scenario:
 
 The script is runnable to move the file to match the new location of the lib file.
 
+## How to Install
+
+1. Clone the repo
+2. Run `dart pub get` in the root of the project
+3. Run `dart pub global activate . --source path --overwrite` in the root of the project
+
 ## How to run
 
 1. clone the repo
 2. locate yourself in the root of your project that you want to sync
-3. run: `dart run path/to/sync_test.dart`
+3. run: `sync_test`
 
 **Note:** Replace path/to/sync_test.dart with the actual path to this cloned script.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,3 +13,6 @@ dependencies:
 dev_dependencies:
   lints: ^3.0.0
   test: ^1.24.0
+
+executables:
+  sync_test:


### PR DESCRIPTION
1. Adds the executable to the pubspec.yaml
    - Running `sync_test` will invoke `bin/sync_test.dart`.
    - The executable can be installed globally

2. Updates READ.me to give instruction on how to install globally


